### PR TITLE
Update opentelemetry dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 tokio = "0.2"
 tracing = "0.1"
 tracing-futures = "0.2.2"
-tracing-opentelemetry = "0.2"
+tracing-opentelemetry = "0.3"
 tracing-subscriber = "0.2"
 
 [dependencies]
@@ -28,7 +28,7 @@ hex = "0.4"
 http = "0.2"
 log = "0.4"
 num_cpus = "1.12"
-opentelemetry = "0.2"
+opentelemetry = "0.4"
 prost = "0.6"
 prost-types = "0.6"
 rustls = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stackdriver"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace."
 documentation = "https://vivint-smarthome.github.io/opentelemetry-stackdriver/opentelemetry_stackdriver/"
 repository = "https://github.com/vivint-smarthome/opentelemetry-stackdriver"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{api::Provider, sdk};
 use opentelemetry_stackdriver::StackDriverExporter;
 use tracing::{span, Level};
-use tracing_opentelemetry::OpentelemetryLayer;
+use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{Layer, Registry};
 
 use std::{path::Path, thread::sleep, time::Duration};
@@ -28,7 +28,7 @@ async fn init_tracing(stackdriver_creds: impl AsRef<Path>) {
         .map_err(|e| panic!("Error connecting to stackdriver: {:?}", e))
         .and_then(|exporter| {
             tracing::subscriber::set_global_default(
-                OpentelemetryLayer::with_tracer(
+                OpenTelemetryLayer::with_tracer(
                     sdk::Provider::builder()
                         .with_simple_exporter(exporter)
                         .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,16 +156,16 @@ impl StackDriverExporter {
                 use proto::google::devtools::cloudtrace::v2::{BatchWriteSpansRequest, Span};
 
                 let spans = batch
-                    .iter()
+                    .into_iter()
                     .map(|span| {
                         let new_attributes = Attributes {
                             attribute_map: span
                                 .attributes
                                 .iter()
-                                .map(|kv| {
+                                .map(|(key, value)| {
                                     (
-                                        kv.key.inner().clone().into_owned(),
-                                        attribute_value_conversion(kv.value.clone()),
+                                        key.inner().clone().into_owned(),
+                                        attribute_value_conversion(value.clone()),
                                     )
                                 })
                                 .collect(),
@@ -178,7 +178,7 @@ impl StackDriverExporter {
                                 .map(|event| TimeEvent {
                                     time: Some(event.timestamp.into()),
                                     value: Some(Value::Annotation(Annotation {
-                                        description: Some(to_truncate(event.message.clone())),
+                                        description: Some(to_truncate(event.name.clone())),
                                         ..Default::default()
                                     })),
                                 })
@@ -190,12 +190,12 @@ impl StackDriverExporter {
                             name: format!(
                                 "projects/{}/traces/{}/spans/{}",
                                 project_name,
-                                hex::encode(span.context.trace_id().to_be_bytes()),
-                                hex::encode(span.context.span_id().to_be_bytes())
+                                hex::encode(span.context.trace_id().to_u128().to_be_bytes()),
+                                hex::encode(span.context.span_id().to_u64().to_be_bytes())
                             ),
                             display_name: Some(to_truncate(span.name.clone())),
-                            span_id: hex::encode(span.context.span_id().to_be_bytes()),
-                            parent_span_id: hex::encode(span.parent_span_id.to_be_bytes()),
+                            span_id: hex::encode(span.context.span_id().to_u64().to_be_bytes()),
+                            parent_span_id: hex::encode(span.parent_span_id.to_u64().to_be_bytes()),
                             start_time: Some(span.start_time.into()),
                             end_time: Some(span.end_time.into()),
                             attributes: Some(new_attributes),


### PR DESCRIPTION
Updates both `opentelemetry` and `tracing-opentelemetry` to their newest version.

We needed this to use the [`OpenTelemetrySpanExt`](https://docs.rs/tracing-opentelemetry/0.3.1/tracing_opentelemetry/trait.OpenTelemetrySpanExt.html) trait provided in `tracing-opentelemetry 0.3` in our tracing integration.

Unfortunately, this is a breaking change as the APIs of these dependencies changed quite a bit.