### PR TITLE
fix: `docs.rs` builds breaking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() {
   tonic_build::configure()
     .build_client(true)
     .build_server(false)
+    .format(std::env::var("DOCS_RS").is_err())
     .compile(
       &[
         "google/devtools/cloudtrace/v2/tracing.proto",


### PR DESCRIPTION
Implements the suggested fix specified for https://github.com/vivint-smarthome/opentelemetry-stackdriver/issues/8. My suggestion for testing this would be to use `cargo publish --allow-dirty` with the version in `Cargo.toml` marked as pre-release , i.e., `0.6.1-alpha.0`.