### PR TITLE
docs: add a step-by-step example for top-level lib documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,29 +22,31 @@
 //!
 //! // The path you want to persist an OAuth2 token. Generally, the lifetime of an OAuth2 token is
 //! // about 1 hour.
-//! let persistent_token_file = Some("oauth_token.json");
+//! let persistent_token_file = Some("oauth_token.json".into());
 //!
 //! // An implementation of `futures::task::Spawn`, which allows our `StackDriverExporter` to
 //! // run new tasks in an `async` runtime, as part of its work.
 //! let spawn = {
-//!   // Neither Tokio nor `async-std` provide APIs implementing `futures::task::Spawn`, but
-//!   // `opentelemetry-stackdriver` uses it because it's a useful abstraction over executor
-//!   // runtimes.
-//!   //
-//!   // https://github.com/tokio-rs/tokio/issues/2018
-//!   // https://github.com/async-rs/async-std/issues/142
-//!   pub struct TokioSpawner;
+//!     // Neither Tokio nor `async-std` provide APIs implementing `futures::task::Spawn`, but
+//!     // `opentelemetry-stackdriver` uses it because it's a useful abstraction over executor
+//!     // runtimes.
+//!     //
+//!     // https://github.com/tokio-rs/tokio/issues/2018
+//!     // https://github.com/async-rs/async-std/issues/142
+//!     pub struct TokioSpawner;
 //!
-//!   impl futures::task::Spawn for TokioSpawner {
-//!     fn spawn_obj(
-//!         &self,
-//!         future: futures::future::FutureObj<'static, ()>
-//!     ) -> Result<(), futures::task::SpawnError> {
-//!       // TODO: check that executor is active; return SpawnError if not.
-//!       tokio::runtime::Handle::current().spawn(future);
-//!       Ok(())
+//!     impl futures::task::Spawn for TokioSpawner {
+//!         fn spawn_obj(
+//!             &self,
+//!             future: futures::future::FutureObj<'static, ()>
+//!         ) -> Result<(), futures::task::SpawnError> {
+//!             // TODO: check that executor is active; return SpawnError if not.
+//!             tokio::runtime::Handle::current().spawn(future);
+//!             Ok(())
+//!         }
 //!     }
-//!   }
+//!
+//!     TokioSpawner
 //! };
 //!
 //! // The amount of time that you, the client, want to give to in-flight span export requests to
@@ -61,19 +63,22 @@
 //! let exporter = StackDriverExporter::connect(
 //!     credentials_path,
 //!     persistent_token_file,
-//!     spawn,
+//!     &spawn,
 //!     maximum_shutdown_duration,
 //!     num_concurrent_requests,
-//! ).await;
+//! ).await.unwrap();
 //!
 //! // An `opentelemetry::sdk::Provider` takes an implementation of `SpanExporter`, which our
 //! // `exporter` does.
-//! let provider = opentelemetry::sdk::Provider::builder()
-//!   // Other builder methods could be used for this too.
-//!   .with_simple_exporter(exporter)
-//!   .build()
-//!   // TODO: Change this name to something more meaningful.
-//!   .get_tracer("example"),
+//! let provider = {
+//!     use opentelemetry::api::Provider; // for `get_tracer` below
+//!     opentelemetry::sdk::Provider::builder()
+//!         // Other builder methods could be used for this too.
+//!         .with_simple_exporter(exporter)
+//!         .build()
+//!         // TODO: Change this name to something more meaningful.
+//!         .get_tracer("example")
+//! };
 //!
 //! // With our `Provider` instance, we can now start making the last remaining (simpler) steps
 //! // towards finally connecting to `tracing`. The target trait on the `tracing` side is
@@ -84,7 +89,7 @@
 //!
 //! // Wrap our `Provider` into a `tracing_subscriber::Layer` by leveraging
 //! // `tracing_opentelemetry`.
-//! let layer = tracing_opentelemetry::OpenTelemetryLayer::with_tracer(provider);
+//! let layer = tracing_opentelemetry::OpenTelemetryLayer::new(provider);
 //!
 //! // A `tracing_subscriber::Registry` is a local backing store for span data -- it
 //! let registry = tracing_subscriber::Registry::default();
@@ -103,7 +108,7 @@
 //!
 //! // ...and now we're ready to go! Start making `tracing::Span`s to your heart's content.
 //!
-//! use {std::thread::sleep, tracing::span};
+//! use {std::{thread::sleep, time::Duration}, tracing::{span, Level}};
 //! span!(Level::INFO, "example_span").in_scope(|| {
 //!     sleep(Duration::from_secs(2));
 //!     span!(Level::INFO, "example_child_span").in_scope(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! // The easiest way to make a custom `Subscriber` implementation is to use the
 //! // `tracing_subscriber` crate as our toolkit.
 //!
-//! // Wrap our `Provider` into a `tracing_subscriber::Layer` by everaging
+//! // Wrap our `Provider` into a `tracing_subscriber::Layer` by leveraging
 //! // `tracing_opentelemetry`.
 //! let layer = tracing_opentelemetry::OpenTelemetryLayer::with_tracer(provider);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@
 //! // `None`, it defaults to 0, meaning, no limit will be enforced.
 //! let num_concurrent_requests = 2;
 //!
-//! // An implementation of `futures::task::Spawn`, which allows .
+//! // An implementation of `futures::task::Spawn`, which allows our `StackDriverExporter` to
+//! // run new tasks in an `async` runtime, as part of its work.
 //! let spawn = {
 //!   // Neither Tokio nor `async-std` provide APIs implementing `futures::task::Spawn`, but
 //!   // `opentelemetry-stackdriver` uses it because it's a useful abstraction over executor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,6 @@
 //! // about 1 hour.
 //! let persistent_token_file = Some("oauth_token.json");
 //!
-//! // The amount of time that you, the client, want to give to in-flight span export requests to
-//! // finish. If you specify `None`, then this defaults to 5 seconds.
-//! let maximum_shutdown_duration = Some(Duration::from_secs(10));
-//!
-//! // The number of span export requests that are allowed to be in-flight at once. If you specify
-//! // `None`, it defaults to 0, meaning, no limit will be enforced.
-//! let num_concurrent_requests = 2;
-//!
 //! // An implementation of `futures::task::Spawn`, which allows our `StackDriverExporter` to
 //! // run new tasks in an `async` runtime, as part of its work.
 //! let spawn = {
@@ -54,6 +46,14 @@
 //!     }
 //!   }
 //! };
+//!
+//! // The amount of time that you, the client, want to give to in-flight span export requests to
+//! // finish. If you specify `None`, then this defaults to 5 seconds.
+//! let maximum_shutdown_duration = Some(Duration::from_secs(10));
+//!
+//! // The number of span export requests that are allowed to be in-flight at once. If you specify
+//! // `None`, it defaults to 0, meaning, no limit will be enforced.
+//! let num_concurrent_requests = 2;
 //!
 //! // `StackDriverExporter`: the focal point of this API.
 //! //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //!     persistent_token_file,
 //!     spawn,
 //!     maximum_shutdown_duration,
+//!     num_concurrent_requests,
 //! ).await;
 //!
 //! // An `opentelemetry::sdk::Provider` takes an implementation of `SpanExporter`, which our


### PR DESCRIPTION
This shouldn't be the place where documentation stops being written (which is being discussed in #7), but it might be a good start. This is very similar to code you can already find in this repo's [`examples/basic.rs`][basic-example] and documentation in other places, like [the doc example for `tracing_opentelemetry::OpenTelemetryLayer::new`][open_telemetry_layer-new]. The focus of these docs, though, is to demonstrate the usage of the API in an incremental style, so that single steps are as easy as possible to understand.

[basic-example]: https://github.com/vivint-smarthome/opentelemetry-stackdriver/blob/102ab6242a891798a8316db5f7bfca463c818507/examples/basic.rs
[open_telemetry_layer-new]: https://docs.rs/tracing-opentelemetry/0.8.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html#examples

Things to do before merging:

- [ ] This PR currently uses default `rustfmt` style, which is _not_ the same as the rest of this project's style configuration. Problem?
- [ ] [`--autosquash`](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash) `fixup!` and `squash!` commits.
- [ ] This currently won't be doctested because of this:

    https://github.com/vivint-smarthome/opentelemetry-stackdriver/blob/38c1e3e43cf7fff5ef001402328a6475de41f1cf/src/lib.rs#L17-L21

    How problematic is this right now?
