### PR TITLE
Factor token provider out into a separate trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3"
 hex = "0.4"
 http = "0.2"
 hyper = "0.13"
-hyper-rustls = "0.20"
+hyper-rustls = { version = "0.20", optional = true }
 log = "0.4"
 opentelemetry = "0.8"
 prost = "0.6"
@@ -36,9 +36,10 @@ prost-types = "0.6"
 rustls = "0.18"
 tonic = { version = "0.3.1", features = ["transport", "tls"] }
 tokio = { version = "0.2", optional = true }
-yup-oauth2 = "4.1"
+yup-oauth2 = { version = "4.1", optional = true }
 webpki-roots = "0.20"
 
 [features]
-default = []
+default = ["yup-authorizer"]
+yup-authorizer = ["hyper-rustls", "yup-oauth2"]
 tokio_adapter = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ tracing-opentelemetry = "0.8"
 tracing-subscriber = { version = "0.2.15", features = ["ansi"] }
 
 [dependencies]
+async-trait = "0.1.41"
 futures = "0.3"
 hex = "0.4"
 http = "0.2"
 hyper = "0.13"
+hyper-rustls = "0.20"
 log = "0.4"
 opentelemetry = "0.8"
 prost = "0.6"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use opentelemetry::sdk::trace::TracerProvider;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_stackdriver::{StackDriverExporter, YupAuthorizer;
+use opentelemetry_stackdriver::{StackDriverExporter, YupAuthorizer};
 use tracing::{span, Level};
 use tracing_subscriber::prelude::*;
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{api::Provider, sdk};
-use opentelemetry_stackdriver::StackDriverExporter;
+use opentelemetry_stackdriver::{StackDriverExporter, YupAuthorizer};
 use tracing::{span, Level};
 use tracing_subscriber::prelude::*;
 
@@ -27,9 +27,8 @@ async fn main() {
 }
 
 async fn init_tracing(stackdriver_creds: impl AsRef<Path>) {
-  let exporter = StackDriverExporter::connect(stackdriver_creds, PathBuf::from("tokens.json"), &TokioSpawner, None, 5)
-    .await
-    .unwrap();
+  let authorizer = YupAuthorizer::new(stackdriver_creds, PathBuf::from("tokens.json")).await.unwrap();
+  let exporter = StackDriverExporter::connect(authorizer, &TokioSpawner, None, 5).await.unwrap();
 
   let provider = sdk::Provider::builder().with_simple_exporter(exporter).build();
   tracing_subscriber::registry()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,13 @@ use std::{
   },
   time::{Duration, Instant},
 };
+#[cfg(feature = "yup-authorizer")]
+use tonic::metadata::MetadataValue;
 use tonic::{
-  metadata::MetadataValue,
   transport::{Channel, ClientTlsConfig},
   Request,
 };
+#[cfg(feature = "yup-authorizer")]
 use yup_oauth2::authenticator::Authenticator;
 
 pub mod proto {
@@ -261,11 +263,13 @@ pub trait Authorizer: Sync + Send + 'static {
   async fn authorize<T: Send + Sync>(&self, request: &mut Request<T>) -> Result<(), Self::Error>;
 }
 
+#[cfg(feature = "yup-authorizer")]
 pub struct YupAuthorizer {
   authenticator: Authenticator<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
   project_id: String,
 }
 
+#[cfg(feature = "yup-authorizer")]
 impl YupAuthorizer {
   pub async fn new(
     credentials_path: impl AsRef<std::path::Path>,
@@ -285,6 +289,7 @@ impl YupAuthorizer {
   }
 }
 
+#[cfg(feature = "yup-authorizer")]
 #[async_trait]
 impl Authorizer for YupAuthorizer {
   type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 // When this PR is merged we should be able to remove this attribute:
 // https://github.com/danburkert/prost/pull/291
 
+use async_trait::async_trait;
 use futures::stream::StreamExt;
-use hyper::client::connect::Connect;
 use opentelemetry::{
   api::core::Value,
   exporter::trace::{ExportResult, SpanData, SpanExporter},
@@ -38,7 +38,7 @@ use std::{
 use tonic::{
   metadata::MetadataValue,
   transport::{Channel, ClientTlsConfig},
-  IntoRequest, Request,
+  Request,
 };
 use yup_oauth2::authenticator::Authenticator;
 
@@ -102,22 +102,13 @@ impl fmt::Debug for StackDriverExporter {
 impl StackDriverExporter {
   /// If `num_concurrent_requests` is set to `0` or `None` then no limit is enforced.
   pub async fn connect<S: futures::task::Spawn>(
-    credentials_path: impl AsRef<std::path::Path>,
-    persistent_token_file: impl Into<Option<std::path::PathBuf>>,
+    authenticator: impl Authorizer,
     spawn: &S,
     maximum_shutdown_duration: Option<Duration>,
     num_concurrent_requests: impl Into<Option<usize>>,
   ) -> Result<Self, Box<dyn std::error::Error>> {
     let num_concurrent_requests = num_concurrent_requests.into();
     let uri = http::uri::Uri::from_static("https://cloudtrace.googleapis.com:443");
-
-    let service_account_key = yup_oauth2::read_service_account_key(&credentials_path).await?;
-    let project_name = service_account_key.project_id.as_ref().ok_or("project_id is missing")?.clone();
-    let mut authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key);
-    if let Some(persistent_token_file) = persistent_token_file.into() {
-      authenticator = authenticator.persist_tokens_to_disk(persistent_token_file);
-    }
-    let authenticator = authenticator.build().await?;
 
     let mut rustls_config = rustls::ClientConfig::new();
     rustls_config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
@@ -131,7 +122,6 @@ impl StackDriverExporter {
       Box::new(Self::export_inner(
         TraceServiceClient::new(channel),
         authenticator,
-        project_name,
         rx,
         pending_count.clone(),
         num_concurrent_requests,
@@ -150,35 +140,21 @@ impl StackDriverExporter {
     self.pending_count.load(Ordering::Relaxed)
   }
 
-  async fn export_inner<C>(
+  async fn export_inner(
     client: TraceServiceClient<Channel>,
-    authenticator: Authenticator<C>,
-    project_name: String,
+    authorizer: impl Authorizer,
     rx: futures::channel::mpsc::Receiver<Vec<Arc<SpanData>>>,
     pending_count: Arc<AtomicUsize>,
     num_concurrent: impl Into<Option<usize>>,
-  ) where
-    C: Connect + Clone + Send + Sync + 'static,
-  {
-    let authenticator = &authenticator;
+  ) {
+    let authorizer = &authorizer;
     rx.for_each_concurrent(num_concurrent, move |batch| {
       let mut client = client.clone(); // This clone is cheap and allows for concurrent requests (see https://github.com/hyperium/tonic/issues/285#issuecomment-595880400)
-      let project_name = project_name.clone();
       let pending_count = pending_count.clone();
       async move {
         use proto::google::devtools::cloudtrace::v2::{
           span::{time_event::Value, Attributes, TimeEvents},
           Span,
-        };
-        let scopes = &["https://www.googleapis.com/auth/trace.append"];
-        let token = authenticator.token(scopes).await;
-        log::trace!("Got StackDriver auth token: {:?}", token);
-        let bearer_token = match token {
-          Ok(token) => format!("Bearer {}", token.as_str()),
-          Err(e) => {
-            log::error!("StackDriver authentication failed {:?}", e);
-            return;
-          }
         };
 
         let spans = batch
@@ -210,7 +186,7 @@ impl StackDriverExporter {
             Span {
               name: format!(
                 "projects/{}/traces/{}/spans/{}",
-                project_name,
+                authorizer.project_id(),
                 hex::encode(span.span_context.trace_id().to_u128().to_be_bytes()),
                 hex::encode(span.span_context.span_id().to_u64().to_be_bytes())
               ),
@@ -226,42 +202,27 @@ impl StackDriverExporter {
           })
           .collect::<Vec<_>>();
 
-        let req = BatchWriteSpansRequest {
-          name: format!("projects/{}", project_name),
+        let mut req = Request::new(BatchWriteSpansRequest {
+          name: format!("projects/{}", authorizer.project_id()),
           spans,
-        };
+        });
+
+        if let Err(e) = authorizer.authorize(&mut req).await {
+          log::error!("StackDriver authentication failed {}", e);
+          return;
+        }
+
         client
-          .batch_write_spans(AuthenticatedRequest::new(req, &bearer_token))
+          .batch_write_spans(req)
           .await
           .map_err(|e| {
-            log::error!("StackDriver push failed {:?}", e);
+            log::error!("StackDriver push failed {}", e);
           })
           .ok();
         pending_count.fetch_sub(1, Ordering::Relaxed);
       }
     })
     .await;
-  }
-}
-
-struct AuthenticatedRequest<'a, T> {
-  inner: T,
-  auth: &'a str,
-}
-
-impl<'a, T> AuthenticatedRequest<'a, T> {
-  pub fn new(inner: T, auth: &'a str) -> Self {
-    Self { inner, auth }
-  }
-}
-
-impl<T> IntoRequest<T> for AuthenticatedRequest<'_, T> {
-  fn into_request(self) -> Request<T> {
-    let mut req = Request::new(self.inner);
-    req
-      .metadata_mut()
-      .insert("authorization", MetadataValue::from_str(&self.auth).unwrap());
-    req
   }
 }
 
@@ -289,6 +250,57 @@ impl SpanExporter for StackDriverExporter {
       std::thread::yield_now();
       // Spin for a bit and give the inner export some time to upload, with a timeout.
     }
+  }
+}
+
+#[async_trait]
+pub trait Authorizer: Sync + Send + 'static {
+  type Error: fmt::Display + fmt::Debug + Send;
+
+  fn project_id(&self) -> &str;
+  async fn authorize<T: Send + Sync>(&self, request: &mut Request<T>) -> Result<(), Self::Error>;
+}
+
+pub struct YupAuthorizer {
+  authenticator: Authenticator<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
+  project_id: String,
+}
+
+impl YupAuthorizer {
+  pub async fn new(
+    credentials_path: impl AsRef<std::path::Path>,
+    persistent_token_file: impl Into<Option<std::path::PathBuf>>,
+  ) -> Result<Self, Box<dyn std::error::Error>> {
+    let service_account_key = yup_oauth2::read_service_account_key(&credentials_path).await?;
+    let project_id = service_account_key.project_id.as_ref().ok_or("project_id is missing")?.clone();
+    let mut authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key);
+    if let Some(persistent_token_file) = persistent_token_file.into() {
+      authenticator = authenticator.persist_tokens_to_disk(persistent_token_file);
+    }
+
+    Ok(Self {
+      authenticator: authenticator.build().await?,
+      project_id,
+    })
+  }
+}
+
+#[async_trait]
+impl Authorizer for YupAuthorizer {
+  type Error = Box<dyn std::error::Error + Send + Sync>;
+
+  fn project_id(&self) -> &str {
+    &self.project_id
+  }
+
+  async fn authorize<T: Send + Sync>(&self, req: &mut Request<T>) -> Result<(), Self::Error> {
+    let scopes = &["https://www.googleapis.com/auth/trace.append"];
+    let token = self.authenticator.token(scopes).await?;
+    req.metadata_mut().insert(
+      "authorization",
+      MetadataValue::from_str(&format!("Bearer {}", token.as_str())).unwrap(),
+    );
+    Ok(())
   }
 }
 


### PR DESCRIPTION
I ran into https://github.com/dermesser/yup-oauth2/issues/137. In general, making the authentication/authorization process more explicit in the type system seems like a good idea (in a future PR, the `YupAuthorizer` and dependency could become optional).