### PR TITLE
Upgrade tracing-subscriber dependency to make example work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "0.2", features = ["rt-core", "rt-threaded"] }
 tracing = "0.1"
 tracing-futures = "0.2.2"
 tracing-opentelemetry = "0.8"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.2.15", features = ["ansi"] }
 
 [dependencies]
 derivative = "2.1.1"


### PR DESCRIPTION
The `pretty()` call was introduced in 102ab624, but this method is
new in tracing-subscriber 0.2.15 (and guarded by the ansi feature).