### PR TITLE
Allow StackDriverExporter to be cloned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub mod tokio_adapter;
 /// As of the time of this writing, the opentelemetry crate exposes no link information
 /// so this struct does not send link information.
 #[derive(Derivative)]
-#[derivative(Debug)]
+#[derivative(Clone, Debug)]
 pub struct StackDriverExporter {
   #[derivative(Debug = "ignore")]
   tx: futures::channel::mpsc::Sender<Vec<Arc<SpanData>>>,


### PR DESCRIPTION
Since it needs to be spawned to be useful, there is no away to access
the `pending_count()` after spawning it. This is useful for debugging.