### PR TITLE
Upgrade to opentelemetry 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,18 @@ futures = { version = "0.3", features = ["thread-pool"] }
 tokio = { version = "0.2", features = ["rt-core", "rt-threaded"] }
 tracing = "0.1"
 tracing-futures = "0.2.2"
-tracing-opentelemetry = "0.8"
+tracing-opentelemetry = "0.9"
 tracing-subscriber = "0.2"
 
 [dependencies]
+async-trait = "0.1.41"
 derivative = "2.1.1"
 futures = "0.3"
 hex = "0.4"
 http = "0.2"
 hyper = "0.13"
 log = "0.4"
-opentelemetry = "0.8"
+opentelemetry = "0.10"
 prost = "0.6"
 prost-types = "0.6"
 rustls = "0.18"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
-use opentelemetry::{api::Provider, sdk};
+use opentelemetry::sdk::trace::TracerProvider;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_stackdriver::StackDriverExporter;
 use tracing::{span, Level};
 use tracing_subscriber::prelude::*;
@@ -31,9 +32,9 @@ async fn init_tracing(stackdriver_creds: impl AsRef<Path>) {
     .await
     .unwrap();
 
-  let provider = sdk::Provider::builder().with_simple_exporter(exporter).build();
+  let provider = TracerProvider::builder().with_simple_exporter(exporter).build();
   tracing_subscriber::registry()
-    .with(tracing_opentelemetry::layer().with_tracer(provider.get_tracer("tracing")))
+    .with(tracing_opentelemetry::layer().with_tracer(provider.get_tracer("tracing", None)))
     .with(tracing_subscriber::filter::LevelFilter::DEBUG)
     .with(tracing_subscriber::fmt::Layer::new().pretty())
     .try_init()


### PR DESCRIPTION
In this version of opentelemetry, retrying is left up to the exporter. I'm not sure what we should do here, if anything. I'm not sure there's a lot we can/should do here if the mpsc channel is already full or if it's failing some other way.